### PR TITLE
derive `Debug` for `TaggedBlobError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Improvements
 
+- Derive `Debug` on `enum TaggedBlobError`
+
 ### Bugfixes
 
 ## v0.1.0 (Initial release of Jellyfish plonk prove system)

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -115,6 +115,7 @@ impl<T: Tagged + CanonicalSerialize + CanonicalDeserialize> From<&T> for TaggedB
     }
 }
 
+#[derive(Debug)]
 pub enum TaggedBlobError {
     Base64Error {
         source: Tb64Error,


### PR DESCRIPTION
## Description

A super minor modification, reported from downstream: 
```rust
// This incurs compilation error:
// the method `unwrap` exists for enum `Result<MyStruct, TaggedBlobError>`, but its trait bound were not satisfied
// the following trait bounds were not satisfied:
// `TaggedBlobError: Debug` [E0599] 
let x = MyStruct::from_str(&ser_str).unwrap();

// currently can only do something like:
let x = MyStruct::from_str(&ser_str).unwrap_or_default();
```
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (main)
- [ ] ~Linked to GitHub issue with discussion and accepted design OR have an explanation in the PR that describes this work.~
- [ ] ~Wrote unit tests~
- [ ] ~Updated relevant documentation in the code~
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] ~Re-reviewed `Files changed` in the GitHub PR explorer~
