### PR TITLE
Derive Snafu for TaggedBlobError.

### DIFF
--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -16,6 +16,7 @@ jf-utils-derive = { path = "../utilities_derive" }
 sha2 = { version = "0.10.1", default-features = false }
 digest = { version = "0.10.1", default-features = false }
 anyhow = { version = "^1.0", default-features = false }
+snafu = { version = "0.7", features = ["backtraces"] }
 
 [dev-dependencies]
 ark-ed-on-bn254 = { version = "0.3.0", default-features = false }

--- a/utilities/src/serialize.rs
+++ b/utilities/src/serialize.rs
@@ -9,6 +9,7 @@
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{marker::PhantomData, string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
+use snafu::Snafu;
 use tagged_base64::{TaggedBase64, Tb64Error};
 
 /// A helper for converting CanonicalSerde bytes to standard Serde bytes.
@@ -115,9 +116,10 @@ impl<T: Tagged + CanonicalSerialize + CanonicalDeserialize> From<&T> for TaggedB
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Snafu)]
 pub enum TaggedBlobError {
     Base64Error {
+        #[snafu(source(false))]
         source: Tb64Error,
     },
     DeserializationError {


### PR DESCRIPTION
This implements Display, which allows us to take TaggedBlob types on the command line using structopt.

